### PR TITLE
Fix null keyword search in EventService

### DIFF
--- a/src/main/java/com/dxjunkyard/community/service/EventService.java
+++ b/src/main/java/com/dxjunkyard/community/service/EventService.java
@@ -42,6 +42,11 @@ public class EventService {
     public List<EventPage> searchEventByKeyword(String keyword) {
         logger.info("keyword search : event");
         try {
+            // キーワードが指定されていない場合は全件取得
+            if (keyword == null || keyword.isBlank()) {
+                return getEventList();
+            }
+
             // todo: keywordをサニタイズする
             // イベント名・概要・PR文をキーワードで検索する
             String decodedKeyword = URLDecoder.decode(keyword, StandardCharsets.UTF_8.name());

--- a/src/test/java/com/dxjunkyard/community/service/EventServiceTest.java
+++ b/src/test/java/com/dxjunkyard/community/service/EventServiceTest.java
@@ -1,0 +1,48 @@
+package com.dxjunkyard.community.service;
+
+import com.dxjunkyard.community.domain.Events;
+import com.dxjunkyard.community.domain.response.EventPage;
+import com.dxjunkyard.community.repository.dao.mapper.EventMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class EventServiceTest {
+
+    @Mock
+    private EventMapper eventMapper;
+
+    @InjectMocks
+    private EventService eventService;
+
+    @Test
+    void searchEventByKeyword_NullKeyword_ReturnsAllEvents() {
+        Events event = new Events();
+        when(eventMapper.getEventList()).thenReturn(List.of(event));
+
+        List<EventPage> result = eventService.searchEventByKeyword(null);
+
+        verify(eventMapper, times(1)).getEventList();
+        verify(eventMapper, never()).searchEvent(any());
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void searchEventByKeyword_ValidKeyword_DelegatesToMapper() {
+        Events event = new Events();
+        when(eventMapper.searchEvent("test")).thenReturn(List.of(event));
+
+        List<EventPage> result = eventService.searchEventByKeyword("test");
+
+        verify(eventMapper).searchEvent("test");
+        assertEquals(1, result.size());
+    }
+}


### PR DESCRIPTION
## Summary
- handle missing keywords in `EventService.searchEventByKeyword`
- add unit tests for `EventService`

## Testing
- `gradle test` *(fails: `LazyPublishArtifact.<init>` error)*

------
https://chatgpt.com/codex/tasks/task_e_68481d5e51388331b815a8303871cda5