### PR TITLE
Add role-based access control

### DIFF
--- a/src/main/java/com/dxjunkyard/community/config/mybatis/CommunityRoleTypeHandler.java
+++ b/src/main/java/com/dxjunkyard/community/config/mybatis/CommunityRoleTypeHandler.java
@@ -1,0 +1,34 @@
+package com.dxjunkyard.community.config.mybatis;
+
+import com.dxjunkyard.community.domain.CommunityRole;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class CommunityRoleTypeHandler extends BaseTypeHandler<CommunityRole> {
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, CommunityRole parameter, JdbcType jdbcType) throws SQLException {
+        ps.setInt(i, parameter.getId());
+    }
+
+    @Override
+    public CommunityRole getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int value = rs.getInt(columnName);
+        return CommunityRole.fromId(rs.wasNull() ? null : value);
+    }
+
+    @Override
+    public CommunityRole getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int value = rs.getInt(columnIndex);
+        return CommunityRole.fromId(rs.wasNull() ? null : value);
+    }
+
+    @Override
+    public CommunityRole getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int value = cs.getInt(columnIndex);
+        return CommunityRole.fromId(cs.wasNull() ? null : value);
+    }
+}

--- a/src/main/java/com/dxjunkyard/community/controller/EventController.java
+++ b/src/main/java/com/dxjunkyard/community/controller/EventController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import com.dxjunkyard.community.service.*;
+import com.dxjunkyard.community.domain.PermissionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,9 @@ public class EventController {
 
     @Autowired
     private EventService eventService;
+
+    @Autowired
+    private AccessControlService accessControlService;
 
     // イベントリストの表示
     @GetMapping("/eventlist")
@@ -97,7 +101,9 @@ public class EventController {
             if (myId == null) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Authorization failed"));
             }
-            // todo : コミュニティに対するイベント作成権限の有無を確認
+            if (!accessControlService.hasPermission(myId, request.getCommunityId(), PermissionType.PLAN_EVENT)) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body("permission denied");
+            }
             // owner_idの指定がない場合は、操作中のユーザーをオーナーに指定する
             if (request.getOwnerId() == null) {
                 request.setOwnerId(myId);

--- a/src/main/java/com/dxjunkyard/community/domain/CommunityMembers.java
+++ b/src/main/java/com/dxjunkyard/community/domain/CommunityMembers.java
@@ -8,6 +8,11 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+/**
+ * Represents a member of a community. The {@link CommunityRole} enum is used
+ * instead of raw integers for the role field.
+ */
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -15,7 +20,7 @@ import java.util.List;
 public class CommunityMembers {
     private Long communityId;
     private String userId;
-    private Integer role;
+    private CommunityRole role;
     private Integer status;
     private Integer fav;
 }

--- a/src/main/java/com/dxjunkyard/community/domain/CommunityRole.java
+++ b/src/main/java/com/dxjunkyard/community/domain/CommunityRole.java
@@ -1,0 +1,31 @@
+package com.dxjunkyard.community.domain;
+
+public enum CommunityRole {
+    VIEWER(1),
+    PARTICIPANT(2),
+    PLANNER(3),
+    RECRUITER(4),
+    ADMIN(5);
+
+    private final int id;
+
+    CommunityRole(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public static CommunityRole fromId(Integer id) {
+        if (id == null) {
+            return VIEWER;
+        }
+        for (CommunityRole r : values()) {
+            if (r.getId() == id) {
+                return r;
+            }
+        }
+        return VIEWER;
+    }
+}

--- a/src/main/java/com/dxjunkyard/community/domain/PermissionType.java
+++ b/src/main/java/com/dxjunkyard/community/domain/PermissionType.java
@@ -1,0 +1,9 @@
+package com.dxjunkyard.community.domain;
+
+public enum PermissionType {
+    VIEW,
+    JOIN,
+    PLAN_EVENT,
+    ISSUE_INVITE,
+    MANAGE_COMMUNITY
+}

--- a/src/main/java/com/dxjunkyard/community/domain/request/AssignRoleRequest.java
+++ b/src/main/java/com/dxjunkyard/community/domain/request/AssignRoleRequest.java
@@ -1,9 +1,11 @@
 package com.dxjunkyard.community.domain.request;
 
 
+import com.dxjunkyard.community.domain.CommunityRole;
 import lombok.Data;
 
 @Data
 public class AssignRoleRequest {
-    private String role;
+    private String userId;
+    private CommunityRole role;
 }

--- a/src/main/java/com/dxjunkyard/community/repository/dao/mapper/CommunityMemberMapper.java
+++ b/src/main/java/com/dxjunkyard/community/repository/dao/mapper/CommunityMemberMapper.java
@@ -1,6 +1,7 @@
 package com.dxjunkyard.community.repository.dao.mapper;
 
 import com.dxjunkyard.community.domain.CommunityMembers;
+import com.dxjunkyard.community.domain.CommunityRole;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -10,5 +11,7 @@ public interface CommunityMemberMapper {
     void insertOrUpdateCommunityMember(CommunityMembers member);
     List<CommunityMembers> selectCommunityMember(Long communityId, String userId);
     //List<String > getMemberNameList(Long communityId);
-    void addCommunityMember(Long community_id, String user_id, Integer role_id, Integer status, Integer fav);
+    void addCommunityMember(Long community_id, String user_id, CommunityRole role_id, Integer status, Integer fav);
+    void updateRole(Long community_id, String user_id, CommunityRole role_id);
+    void deleteCommunityMember(Long community_id, String user_id);
 }

--- a/src/main/java/com/dxjunkyard/community/service/AccessControlService.java
+++ b/src/main/java/com/dxjunkyard/community/service/AccessControlService.java
@@ -1,0 +1,39 @@
+package com.dxjunkyard.community.service;
+
+import com.dxjunkyard.community.domain.CommunityRole;
+import com.dxjunkyard.community.domain.PermissionType;
+import com.dxjunkyard.community.repository.dao.mapper.CommunityMemberMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AccessControlService {
+    @Autowired
+    private CommunityMemberMapper communityMemberMapper;
+
+    public boolean hasPermission(String userId, Long communityId, PermissionType action) {
+        CommunityRole role = getRole(userId, communityId);
+        switch (action) {
+            case VIEW:
+                return true;
+            case JOIN:
+                return role.getId() >= CommunityRole.PARTICIPANT.getId();
+            case PLAN_EVENT:
+                return role.getId() >= CommunityRole.PLANNER.getId();
+            case ISSUE_INVITE:
+                return role.getId() >= CommunityRole.RECRUITER.getId();
+            case MANAGE_COMMUNITY:
+                return role.getId() >= CommunityRole.ADMIN.getId();
+            default:
+                return false;
+        }
+    }
+
+    private CommunityRole getRole(String userId, Long communityId) {
+        return communityMemberMapper.selectCommunityMember(communityId, userId)
+                .stream()
+                .map(m -> m.getRole())
+                .findFirst()
+                .orElse(CommunityRole.VIEWER);
+    }
+}

--- a/src/main/java/com/dxjunkyard/community/service/CommunityMemberService.java
+++ b/src/main/java/com/dxjunkyard/community/service/CommunityMemberService.java
@@ -1,6 +1,7 @@
 package com.dxjunkyard.community.service;
 
 import com.dxjunkyard.community.domain.CommunityMembers;
+import com.dxjunkyard.community.domain.CommunityRole;
 import com.dxjunkyard.community.domain.Invitations;
 import com.dxjunkyard.community.domain.request.FavoriteRequest;
 import com.dxjunkyard.community.repository.dao.mapper.CommunityMemberMapper;
@@ -19,7 +20,7 @@ public class CommunityMemberService {
     @Autowired
     private InvitationMapper invitationMapper;
 
-    public Integer  updateFavoriteStatus(String userId, Integer roleId, FavoriteRequest request) {
+    public Integer  updateFavoriteStatus(String userId, CommunityRole roleId, FavoriteRequest request) {
         try {
             CommunityMembers member = CommunityMembers.builder()
                     .userId(userId)
@@ -34,6 +35,29 @@ public class CommunityMemberService {
         } catch (Exception e) {
             return 0;
         }
+    }
+
+    public CommunityRole getRole(Long communityId, String userId) {
+        List<CommunityMembers> members = communityMemberMapper.selectCommunityMember(communityId, userId);
+        if (members.isEmpty()) {
+            return CommunityRole.VIEWER;
+        }
+        return members.get(0).getRole();
+    }
+
+    public void assignRole(Long communityId, String targetUser, CommunityRole role) {
+        CommunityMembers member = CommunityMembers.builder()
+                .communityId(communityId)
+                .userId(targetUser)
+                .role(role)
+                .status(1)
+                .fav(1)
+                .build();
+        communityMemberMapper.insertOrUpdateCommunityMember(member);
+    }
+
+    public void removeMember(Long communityId, String targetUser) {
+        communityMemberMapper.deleteCommunityMember(communityId, targetUser);
     }
 
     public List<String> getMemberNameList(Long communityId) {

--- a/src/main/java/com/dxjunkyard/community/service/CommunityService.java
+++ b/src/main/java/com/dxjunkyard/community/service/CommunityService.java
@@ -65,7 +65,7 @@ public class CommunityService {
             // 日付チェックも入れる
             if (invitation.getRemainingUses() >= 0) {
                 Long communityId = invitation.getCommunityId();
-                communityMemberMapper.addCommunityMember(communityId, myId, 100, 1, 1);
+                communityMemberMapper.addCommunityMember(communityId, myId, CommunityRole.PARTICIPANT, 1, 1);
                 return communityId;
             } else {
                 return null;
@@ -264,7 +264,7 @@ public class CommunityService {
                     .visibility(request.getVisibility())
                     .build();
             communityMapper.addCommunity(community);
-            communityMemberMapper.addCommunityMember(community.getId(),community.getOwnerId(),100,1,1);
+            communityMemberMapper.addCommunityMember(community.getId(),community.getOwnerId(),CommunityRole.ADMIN,1,1);
             return community;
         } catch (Exception e) {
             logger.info("addCommunity error");
@@ -319,7 +319,7 @@ public class CommunityService {
                     .build();
             communityMapper.addCommunity(community);
             // 作成した親コミュニティメンバーとしてコミュニティ作成者を追加する
-            communityMemberMapper.addCommunityMember(community.getId(),community.getOwnerId(),100,1,1);
+            communityMemberMapper.addCommunityMember(community.getId(),community.getOwnerId(),CommunityRole.ADMIN,1,1);
 
             // 親コミュニティIDを取得
             Long parentCommunityId =  community.getId();

--- a/src/main/resources/com/dxjunkyard/community/repository/dao/mapper/CommunityMemberMapper.xml
+++ b/src/main/resources/com/dxjunkyard/community/repository/dao/mapper/CommunityMemberMapper.xml
@@ -15,23 +15,31 @@
         VALUES (
                    #{communityId},
                    #{userId},
-                   #{role},
+                   #{role, typeHandler=com.dxjunkyard.community.config.mybatis.CommunityRoleTypeHandler},
                    #{status},
                    #{fav}
                )
             ON DUPLICATE KEY UPDATE
-                                 role_id = #{role},
-                                 status = #{status},
-                                 fav_flg = #{fav};
+                                role_id = #{role, typeHandler=com.dxjunkyard.community.config.mybatis.CommunityRoleTypeHandler},
+                                status = #{status},
+                                fav_flg = #{fav};
     </insert>
     <!-- Select CommunityMember by communityId and userId -->
-    <select id="selectCommunityMember" resultType="com.dxjunkyard.community.domain.CommunityMembers">
+    <resultMap id="CommunityMemberResult" type="com.dxjunkyard.community.domain.CommunityMembers">
+        <result column="community_id" property="communityId"/>
+        <result column="user_id" property="userId"/>
+        <result column="role_id" property="role" javaType="com.dxjunkyard.community.domain.CommunityRole"
+                typeHandler="com.dxjunkyard.community.config.mybatis.CommunityRoleTypeHandler"/>
+        <result column="status" property="status"/>
+        <result column="fav_flg" property="fav"/>
+    </resultMap>
+    <select id="selectCommunityMember" resultMap="CommunityMemberResult">
         SELECT
-            community_id as communityId
-            ,user_id as userId
-            ,role_id as role
-            ,status as status
-            ,fav_flg as fav
+            community_id,
+            user_id,
+            role_id,
+            status,
+            fav_flg
         FROM CommunityMembers
         WHERE community_id = #{communityId}
           AND user_id = #{userId}
@@ -46,9 +54,22 @@
         values (
                    #{community_id},
                    #{user_id},
-                   #{role_id},
+                   #{role_id, typeHandler=com.dxjunkyard.community.config.mybatis.CommunityRoleTypeHandler},
                    #{status},
                    #{fav}
                )
     </insert>
+
+    <update id="updateRole">
+        UPDATE CommunityMembers
+        SET role_id = #{role_id, typeHandler=com.dxjunkyard.community.config.mybatis.CommunityRoleTypeHandler}
+        WHERE community_id = #{community_id}
+          AND user_id = #{user_id}
+    </update>
+
+    <delete id="deleteCommunityMember">
+        DELETE FROM CommunityMembers
+        WHERE community_id = #{community_id}
+          AND user_id = #{user_id}
+    </delete>
 </mapper>


### PR DESCRIPTION
## Summary
- introduce `CommunityRole` enum and `PermissionType`
- implement `AccessControlService` and MyBatis type handler
- use `CommunityRole` in `CommunityMembers`
- enforce role checks in controller endpoints
- ensure default role assignment during community creation

## Testing
- `gradle test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8c40a008331bb88091cef42215c